### PR TITLE
Zero I term if I coefficient set to zero

### DIFF
--- a/src/ArduPID.cpp
+++ b/src/ArduPID.cpp
@@ -105,7 +105,7 @@ void ArduPID::compute()
 
 		dOut = -kd * dInput; // Derrivative on measurement
 
-		double iTemp = iOut + (ki * ((curError + lastError) / 2.0)); // Trapezoidal integration
+		double iTemp = (iIn == 0.0) ? 0.0 : iOut + (ki * ((curError + lastError) / 2.0)); // Trapezoidal integration
 		iTemp        = constrain(iTemp, windupMin, windupMax);       // Prevent integral windup
 
 		double outTemp = bias + pOut + dOut;                           // Output without integral


### PR DESCRIPTION
Currently, when setting a finite integral coefficient, the `iOut` term will reach some value. If the coefficient is then set to zero, the `iOut` term keeps its last value.

I don't think this is a bug as such, but is unexpected behaviour. For example, if at some point we call `setCoefficients(0.0, 0.0, 0.0)` we would expect the output to become zero. Instead, the output changes to some non-zero value equal to the current value of `iOut`. Calling `reset()` will set `iOut` to zero and "fix" the problem, but also resets everything else, so isn't a great solution.

This change modifies the line:
```c
double iTemp = iOut + (ki * ((curError + lastError) / 2.0));
```
to
```c
double iTemp = (iIn == 0.0) ? 0.0 : iOut + (ki * ((curError + lastError) / 2.0));
```
so that setting the integral coefficient to zero instantly removes its effect from the output. Note that the integral windup limits are still respected in case the integral windup minimum is set > 0 for some reason.
