### PR TITLE
Separated compute logic from timer

### DIFF
--- a/src/ArduPID.h
+++ b/src/ArduPID.h
@@ -47,6 +47,7 @@ public:
 	void reset();
 	void stop();
 	virtual void compute();
+    void doCompute(ulong timeDiff);
 	void setOutputLimits(const double& min, const double& max);
 	void setWindUpLimits(const double& min, const double& max);
 	void setDeadBand(const double& min, const double& max);


### PR DESCRIPTION
In my application, the control logic needs some things to happen after the timer fires but before `compute()` is called, so I separated the timer call from the compute logic.